### PR TITLE
Fix link to Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,53 @@
 version: 2
 
-defaults: &defaults
-  docker:
-    -
-      image: docker:18.05.0-ce-git
-  working_directory: ~/repo
-  steps:
-    - checkout
-    - setup_remote_docker
-    -
-      run:
-        name: Build application Docker image
-        command: |
-          docker build --tag box-builder:$VERSION $VERSION/
-    -
-      run:
-        name: List created images
-        command: |
-          docker images
+.tempates:
+  .validate_template: &validate_template
+    docker:
+      -
+        image: finalgene/hadolint:latest
+    working_directory: /app
+    steps:
+      - checkout
+      - setup_remote_docker
+      -
+        run:
+          name: Validate Dockerfile
+          command: |
+            hadolint $VERSION/Dockerfile
+  .build_template: &build_template
+    docker:
+      -
+        image: docker:18.05.0-ce-git
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - setup_remote_docker
+      -
+        run:
+          name: Build application Docker image
+          command: |
+            docker build --tag box-builder:$VERSION $VERSION/
+      -
+        run:
+          name: List created images
+          command: |
+            docker images
 
 jobs:
+  validate-2.7:
+    environment:
+      VERSION: "2.7"
+    <<: *validate_template
   build-2.7:
     environment:
       VERSION: "2.7"
-    <<: *defaults
+    <<: *build_template
 
 workflows:
   version: 2
-  build:
+  validate_and_build:
     jobs:
-      - build-2.7
+      - validate-2.7
+      - build-2.7:
+          requires:
+            - validate-2.7

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer="frank.giesecke@final-gene.de"
 
 ENV BOX2_VERSION 2.7.5
 
+SHELL ["/bin/sh", "-o", "pipefail", "-c"]
+
 RUN apk add --no-cache --virtual=.persitent \
         curl=7.60.0-r1 \
         git=2.15.2-r0 \

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -4,7 +4,9 @@ LABEL maintainer="frank.giesecke@final-gene.de"
 
 ENV BOX2_VERSION 2.7.5
 
-SHELL ["/bin/sh", "-o", "pipefail", "-c"]
+RUN apk add --no-cache --virtual=.build-deps bash
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apk add --no-cache --virtual=.persitent \
         curl=7.60.0-r1 \
@@ -24,6 +26,8 @@ RUN curl -LSs \
         -o /usr/local/bin/box \
         "https://github.com/box-project/box2/releases/download/${BOX2_VERSION}/box-${BOX2_VERSION}.phar" \
     && chmod a+x /usr/local/bin/box
+
+RUN apk del .build-deps
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is a image to run [box-builder (box2)](https://github.com/box-project/box2).
 
 ## Supported tags and respective Dockerfile links
-* `2.7`, `latest` [(Dockerfile)](https://github.com/finalgene/docker-hub-box-builder/blob/master/2.6/Dockerfile)
+* `2.7`, `latest` [(2.7/Dockerfile)](https://github.com/finalgene/docker-hub-box-builder/blob/master/2.7/Dockerfile)
 
 ## How to use this image
 Run the `box-builder` image:


### PR DESCRIPTION
The `README.md` contains an invalid link to the `Dockerfile` for version 2.7.
Also beware the [pipe fail](https://github.com/hadolint/hadolint/wiki/DL4006#set-the-shell-option--o-pipefail-before-run-with-a-pipe-in) during build process.